### PR TITLE
Fix docs rendering issue

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -174,7 +174,7 @@ See [bmewburn/intelephense-server/](https://github.com/bmewburn/intelephense-ser
           "storagePath": "PATH_TO_TEMP_FOLDER/intelephense-ls",
       },
   },
-  ```
+```
 
 ### Ruby / Ruby on Rails<a name="ruby"></a>
 
@@ -491,7 +491,6 @@ Any fields in a client configuration can be overridden by adding an LSP settings
     }
   }
 }
-
 ```
 
 


### PR DESCRIPTION
Some whitespace in `docs/index.md` was causing the docs to render like so:
![screen shot 2018-10-08 at 16 47 23](https://user-images.githubusercontent.com/4761135/46616695-a26d8c80-cb0a-11e8-976a-1adfec900139.png)
